### PR TITLE
Add YamlGuardian core functionality

### DIFF
--- a/tests/test_cerberus_adapter.py
+++ b/tests/test_cerberus_adapter.py
@@ -1,0 +1,25 @@
+import unittest
+from yamlguardian.cerberus_adapter import convert_yaml_to_cerberus, load_yaml_file
+
+class TestCerberusAdapter(unittest.TestCase):
+
+    def test_convert_yaml_to_cerberus(self):
+        yaml_schema = {
+            'name': {'type': 'string', 'minlength': 1, 'maxlength': 50, 'required': True},
+            'age': {'type': 'integer', 'min': 0, 'required': True}
+        }
+        cerberus_schema = convert_yaml_to_cerberus(yaml_schema)
+        self.assertEqual(cerberus_schema['name']['type'], 'string')
+        self.assertEqual(cerberus_schema['name']['minlength'], 1)
+        self.assertEqual(cerberus_schema['name']['maxlength'], 50)
+        self.assertEqual(cerberus_schema['name']['required'], True)
+        self.assertEqual(cerberus_schema['age']['type'], 'integer')
+        self.assertEqual(cerberus_schema['age']['min'], 0)
+        self.assertEqual(cerberus_schema['age']['required'], True)
+
+    def test_load_yaml_file(self):
+        yaml_content = load_yaml_file('tests/test_schema.yaml')
+        self.assertIsInstance(yaml_content, dict)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+import unittest
+import subprocess
+import os
+
+class TestCLI(unittest.TestCase):
+
+    def test_cli_success(self):
+        result = subprocess.run(['python', '-m', 'yamlguardian.cli', 'tests/test_data.yaml', 'tests/test_schema.yaml'], capture_output=True, text=True)
+        self.assertIn("Validation succeeded.", result.stdout)
+
+    def test_cli_failure(self):
+        result = subprocess.run(['python', '-m', 'yamlguardian.cli', 'tests/test_invalid_data.yaml', 'tests/test_schema.yaml'], capture_output=True, text=True)
+        self.assertIn("Validation failed with the following errors:", result.stdout)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,30 @@
+import unittest
+import yaml
+from yamlguardian.validate import load_yaml_schema, validate_data, format_errors
+
+class TestValidate(unittest.TestCase):
+
+    def test_load_yaml_schema(self):
+        schema = load_yaml_schema('tests/test_schema.yaml')
+        self.assertIsInstance(schema, dict)
+
+    def test_validate_data(self):
+        schema = load_yaml_schema('tests/test_schema.yaml')
+        data = {'name': 'John', 'age': 30}
+        errors = validate_data(data, schema)
+        self.assertIsNone(errors)
+
+    def test_validate_data_with_errors(self):
+        schema = load_yaml_schema('tests/test_schema.yaml')
+        data = {'name': 'John'}
+        errors = validate_data(data, schema)
+        self.assertIsNotNone(errors)
+
+    def test_format_errors(self):
+        errors = {'name': ['required field'], 'age': ['min value is 18']}
+        formatted_errors = format_errors(errors)
+        self.assertIn('name: required field', formatted_errors)
+        self.assertIn('age: min value is 18', formatted_errors)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yamlguardian/cerberus_adapter.py
+++ b/yamlguardian/cerberus_adapter.py
@@ -1,0 +1,23 @@
+import yaml
+
+def convert_yaml_to_cerberus(yaml_schema):
+    cerberus_schema = {}
+    for field, rules in yaml_schema.items():
+        cerberus_rules = {}
+        for rule, value in rules.items():
+            if rule == 'type':
+                cerberus_rules['type'] = value
+            elif rule == 'minlength':
+                cerberus_rules['minlength'] = value
+            elif rule == 'maxlength':
+                cerberus_rules['maxlength'] = value
+            elif rule == 'required':
+                cerberus_rules['required'] = value
+            # Add more mappings as needed
+        cerberus_schema[field] = cerberus_rules
+    return cerberus_schema
+
+def load_yaml_file(file_path):
+    with open(file_path, 'r') as file:
+        yaml_content = yaml.safe_load(file)
+    return yaml_content

--- a/yamlguardian/cli.py
+++ b/yamlguardian/cli.py
@@ -1,0 +1,24 @@
+import argparse
+import yaml
+from yamlguardian.validate import load_yaml_schema, validate_data, format_errors
+from yamlguardian.cerberus_adapter import convert_yaml_to_cerberus, load_yaml_file
+
+def main():
+    parser = argparse.ArgumentParser(description='Validate data against a YAML schema.')
+    parser.add_argument('data', type=str, help='Path to the YAML data file.')
+    parser.add_argument('schema', type=str, help='Path to the YAML schema file.')
+    args = parser.parse_args()
+
+    data = load_yaml_file(args.data)
+    yaml_schema = load_yaml_schema(args.schema)
+    cerberus_schema = convert_yaml_to_cerberus(yaml_schema)
+    errors = validate_data(data, cerberus_schema)
+
+    if errors:
+        print("Validation failed with the following errors:")
+        print(format_errors(errors))
+    else:
+        print("Validation succeeded.")
+
+if __name__ == "__main__":
+    main()

--- a/yamlguardian/validate.py
+++ b/yamlguardian/validate.py
@@ -1,0 +1,24 @@
+import yaml
+from cerberus import Validator
+
+def load_yaml_schema(file_path):
+    with open(file_path, 'r') as file:
+        schema = yaml.safe_load(file)
+    return schema
+
+def validate_data(data, schema):
+    v = Validator(schema)
+    if not v.validate(data):
+        return v.errors
+    return None
+
+def format_errors(errors):
+    formatted_errors = []
+    for field, error in errors.items():
+        if isinstance(error, list):
+            for e in error:
+                formatted_errors.append(f"{field}: {e}")
+        elif isinstance(error, dict):
+            for subfield, suberror in error.items():
+                formatted_errors.append(f"{field}.{subfield}: {suberror}")
+    return "\n".join(formatted_errors)


### PR DESCRIPTION
Add core functionality for YamlGuardian including schema loading, data validation, and CLI interface.

* **yamlguardian/validate.py**: Implement functions to load YAML schema, validate data using Cerberus, and format validation errors.
* **yamlguardian/cerberus_adapter.py**: Implement functions to convert YAML schema to Cerberus schema and load YAML files.
* **yamlguardian/cli.py**: Implement CLI interface to validate data against schema using `argparse`.
* **tests/test_validate.py**: Add unit tests for `validate.py` module, including tests for loading YAML schema, validating data, and formatting errors.
* **tests/test_cerberus_adapter.py**: Add unit tests for `cerberus_adapter.py` module, including tests for converting YAML schema to Cerberus schema and loading YAML files.
* **tests/test_cli.py**: Add unit tests for `cli.py` module, including tests for CLI interface validation success and failure scenarios.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/1?shareId=78816cb6-743a-41c2-ad79-062e5689f9bb).