### PR TITLE
Add CI using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyyaml cerberus
+    - name: Run tests
+      run: |
+        python -m unittest discover -s tests

--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # YamlGuardian
 YamlGuardian
+
+## Continuous Integration
+
+This project uses GitHub Actions for continuous integration. The CI workflow is defined in the `.github/workflows/ci.yml` file. It runs tests on every push and pull request to ensure the codebase remains stable.


### PR DESCRIPTION
Add GitHub Actions workflow for continuous integration.

* Create a new directory `.github/workflows`.
* Add a new file `.github/workflows/ci.yml` to define the CI workflow.
* Configure the workflow to run on push and pull request events.
* Define jobs for building and testing the project.
* Include steps for setting up Python, installing dependencies, and running tests.
* Update `README.md` to include a section about CI/CD using GitHub Actions and mention the CI workflow file location and purpose.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/2?shareId=eab343e4-7686-41af-8ab6-bce921bdebca).