### PR TITLE
Update directory structure for YAML definitions

### DIFF
--- a/rule_config/common_definitions/common_definitions.yaml
+++ b/rule_config/common_definitions/common_definitions.yaml
@@ -1,0 +1,14 @@
+common_elements:
+  - name: commonLabel
+    type: label
+    description: "共通ラベル"
+    required: true
+    attributes:
+      for: "commonInput"
+
+  - name: commonRadio
+    type: radio
+    description: "共通ラジオボタン"
+    required: false
+    attributes:
+      name: "commonOptions"

--- a/rule_config/page_definitions/page1/form1.yaml
+++ b/rule_config/page_definitions/page1/form1.yaml
@@ -1,0 +1,37 @@
+root_element:
+  name: "FormA"
+  type: "form"
+  description: "このフォームはラベルとラジオボタンの関係を定義します。"
+  attributes:
+    action: "/submit"
+    method: "post"
+  elements:
+    - name: AAA
+      type: label
+      description: "このラベルは必須です。"
+      required: true
+      attributes:
+        for: "input1"
+      check:
+        condition: "every"
+        target: "label"
+
+    - name: BBB
+      type: radio
+      description: "このラジオボタンはオプションです。"
+      required: false
+      attributes:
+        id: "input1"
+        name: "options"
+      prohibited: false
+      check:
+        condition: "first_only"
+        target: "radio"
+
+    - name: commonLabel
+      type: label
+      description: "共通ラベルを使用しています。"
+      required: true
+      attributes:
+        for: "commonInput"
+      uses_common: true  # 共通要素を使用することを明示

--- a/rule_config/page_definitions/page1/root_element_relations.yaml
+++ b/rule_config/page_definitions/page1/root_element_relations.yaml
@@ -1,0 +1,7 @@
+root_element_relations:
+  - source: "FormA"
+    target: "FormB"
+    condition: "exists"  # FormAが存在する場合にFormBをチェック
+  - source: "FormC"
+    target: "commonLabel"
+    condition: "uses_common"  # FormCが共通ラベルを使用する場合

--- a/rule_config/page_definitions/page2/form1.yaml
+++ b/rule_config/page_definitions/page2/form1.yaml
@@ -1,0 +1,37 @@
+root_element:
+  name: "FormD"
+  type: "form"
+  description: "このフォームはラベルとラジオボタンの関係を定義します。"
+  attributes:
+    action: "/submit"
+    method: "post"
+  elements:
+    - name: CCC
+      type: label
+      description: "このラベルは必須です。"
+      required: true
+      attributes:
+        for: "input2"
+      check:
+        condition: "every"
+        target: "label"
+
+    - name: DDD
+      type: radio
+      description: "このラジオボタンはオプションです。"
+      required: false
+      attributes:
+        id: "input2"
+        name: "options"
+      prohibited: false
+      check:
+        condition: "first_only"
+        target: "radio"
+
+    - name: commonRadio
+      type: radio
+      description: "共通ラジオボタンを使用しています。"
+      required: false
+      attributes:
+        name: "commonOptions"
+      uses_common: true  # 共通要素を使用することを明示

--- a/rule_config/page_definitions/page2/root_element_relations.yaml
+++ b/rule_config/page_definitions/page2/root_element_relations.yaml
@@ -1,0 +1,7 @@
+root_element_relations:
+  - source: "FormD"
+    target: "FormE"
+    condition: "exists"  # FormDが存在する場合にFormEをチェック
+  - source: "FormF"
+    target: "commonRadio"
+    condition: "uses_common"  # FormFが共通ラジオボタンを使用する場合

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -3,6 +3,7 @@ import yaml
 from yamlguardian.validate import load_yaml_schema, validate_data, format_errors
 from yamlguardian.validator import Validator
 from yamlguardian.rules import RuleManager
+from yamlguardian.core import YamlGuardian
 
 class TestValidate(unittest.TestCase):
 
@@ -59,6 +60,66 @@ class TestValidate(unittest.TestCase):
         data_invalid = {'custom_field': 'invalid_value'}
         errors_invalid = rule_manager.validate(data_invalid)
         self.assertNotEqual(errors_invalid, [])
+
+    def test_yaml_guardian_page_definitions(self):
+        yaml_guardian = YamlGuardian(
+            schema_file='rule_config/common_definitions/common_definitions.yaml',
+            relations_file='rule_config/page_definitions/page1/root_element_relations.yaml',
+            common_definitions_file='rule_config/common_definitions/common_definitions.yaml'
+        )
+        page_data = {
+            'root_element': {
+                'name': 'FormA',
+                'type': 'form',
+                'description': 'このフォームはラベルとラジオボタンの関係を定義します。',
+                'attributes': {
+                    'action': '/submit',
+                    'method': 'post'
+                },
+                'elements': [
+                    {
+                        'name': 'AAA',
+                        'type': 'label',
+                        'description': 'このラベルは必須です。',
+                        'required': True,
+                        'attributes': {
+                            'for': 'input1'
+                        },
+                        'check': {
+                            'condition': 'every',
+                            'target': 'label'
+                        }
+                    },
+                    {
+                        'name': 'BBB',
+                        'type': 'radio',
+                        'description': 'このラジオボタンはオプションです。',
+                        'required': False,
+                        'attributes': {
+                            'id': 'input1',
+                            'name': 'options'
+                        },
+                        'prohibited': False,
+                        'check': {
+                            'condition': 'first_only',
+                            'target': 'radio'
+                        }
+                    },
+                    {
+                        'name': 'commonLabel',
+                        'type': 'label',
+                        'description': '共通ラベルを使用しています。',
+                        'required': True,
+                        'attributes': {
+                            'for': 'commonInput'
+                        },
+                        'uses_common': True
+                    }
+                ]
+            }
+        }
+        errors = yaml_guardian.validate_page(page_data, 'rule_config/page_definitions/page1')
+        self.assertIsNone(errors)
 
 if __name__ == '__main__':
     unittest.main()

--- a/yamlguardian/core.py
+++ b/yamlguardian/core.py
@@ -2,6 +2,7 @@ import yaml
 from .validator import Validator
 from .rules import RuleManager
 from .validate import load_yaml_schema, validate_data, format_errors
+import os
 
 class YamlGuardian:
     def __init__(self, schema_file, relations_file=None, common_definitions_file=None):
@@ -20,3 +21,21 @@ class YamlGuardian:
         if errors:
             return format_errors(errors)
         return self.rule_manager.validate(data)
+
+    def load_page_definitions(self, page_definitions_dir):
+        page_definitions = {}
+        for root, _, files in os.walk(page_definitions_dir):
+            for file in files:
+                if file.endswith('.yaml'):
+                    file_path = os.path.join(root, file)
+                    page_definitions[file_path] = self.load_yaml(file_path)
+        return page_definitions
+
+    def validate_page(self, page_data, page_definitions_dir):
+        page_definitions = self.load_page_definitions(page_definitions_dir)
+        for file_path, definition in page_definitions.items():
+            schema = load_yaml_schema(definition)
+            errors = validate_data(page_data, schema)
+            if errors:
+                return format_errors(errors)
+        return self.rule_manager.validate(page_data)

--- a/yamlguardian/rules.py
+++ b/yamlguardian/rules.py
@@ -30,4 +30,10 @@ class RuleManager:
                 for rule in element['custom_rules']:
                     if not rule(data.get(element['name'])):
                         errors.append(f"{element['description']} のカスタムルールに違反しています。")
+
+            # Check for uses_common attribute
+            if element.get('uses_common'):
+                common_element = next((e for e in self.common_definitions.get('common_elements', []) if e['name'] == element['name']), None)
+                if not common_element:
+                    errors.append(f"{element['description']} は共通要素として定義されていません。")
         return errors


### PR DESCRIPTION
Update the directory structure and add new YAML files for common definitions and page-specific definitions.

* **Add common definitions:**
  - Add `rule_config/common_definitions/common_definitions.yaml` to define `common_elements` with `commonLabel` and `commonRadio`.

* **Add page-specific definitions for page1:**
  - Add `rule_config/page_definitions/page1/root_element_relations.yaml` to define `root_element_relations` with `FormA` to `FormB` and `FormC` to `commonLabel`.
  - Add `rule_config/page_definitions/page1/form1.yaml` to define `root_element` with `FormA` and elements `AAA`, `BBB`, and `commonLabel`.

* **Add page-specific definitions for page2:**
  - Add `rule_config/page_definitions/page2/root_element_relations.yaml` to define `root_element_relations` with `FormD` to `FormE` and `FormF` to `commonRadio`.
  - Add `rule_config/page_definitions/page2/form1.yaml` to define `root_element` with `FormD` and elements `CCC`, `DDD`, and `commonRadio`.

* **Update core.py:**
  - Update `YamlGuardian` class to load new directory structure.
  - Add methods to load page definitions and validate page data.

* **Update rules.py:**
  - Add logic to check for `uses_common` attribute in `RuleManager`.

* **Update tests/test_validate.py:**
  - Add tests for new directory structure.
  - Add tests for `uses_common` attribute.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/5?shareId=ae3e6593-1f88-4948-9271-3db40eca644e).