### PR TITLE
Add DirectoryAnalyzer class to analyze directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,13 @@ To run the edge case tests, use the following command:
 ```sh
 poetry run python -m unittest tests/test_validate.py
 ```
+
+### Analyzing Directory Structure
+
+To analyze the directory structure and identify necessary changes, run the following script:
+
+```sh
+poetry run python yamlguardian/directory_analyzer.py
+```
+
+The identified changes will be saved in a CSV file named `directory_structure_changes.csv` in the root directory.

--- a/tests/test_directory_analyzer.py
+++ b/tests/test_directory_analyzer.py
@@ -1,0 +1,56 @@
+import unittest
+import os
+import csv
+from yamlguardian.directory_analyzer import DirectoryAnalyzer
+
+class TestDirectoryAnalyzer(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = 'test_directory'
+        os.makedirs(self.test_dir, exist_ok=True)
+        with open(os.path.join(self.test_dir, 'test_file.txt'), 'w') as f:
+            f.write('test content')
+        with open(os.path.join(self.test_dir, 'test_file.yaml'), 'w') as f:
+            f.write('name: test\nage: 30')
+
+    def tearDown(self):
+        for root, dirs, files in os.walk(self.test_dir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        os.rmdir(self.test_dir)
+
+    def test_analyze_directory_structure(self):
+        analyzer = DirectoryAnalyzer()
+        changes = analyzer.analyze_directory_structure(self.test_dir)
+        self.assertEqual(len(changes), 3)
+        self.assertEqual(changes[0], ['Directory', self.test_dir])
+        self.assertEqual(changes[1], ['File', os.path.join(self.test_dir, 'test_file.txt')])
+        self.assertEqual(changes[2], ['File', os.path.join(self.test_dir, 'test_file.yaml')])
+
+    def test_save_changes_to_csv(self):
+        analyzer = DirectoryAnalyzer()
+        changes = analyzer.analyze_directory_structure(self.test_dir)
+        csv_file = 'test_directory_structure_changes.csv'
+        analyzer.save_changes_to_csv(changes, csv_file)
+        with open(csv_file, 'r') as f:
+            reader = csv.reader(f)
+            rows = list(reader)
+            self.assertEqual(len(rows), 4)
+            self.assertEqual(rows[0], ['Type', 'Path'])
+            self.assertEqual(rows[1], ['Directory', self.test_dir])
+            self.assertEqual(rows[2], ['File', os.path.join(self.test_dir, 'test_file.txt')])
+            self.assertEqual(rows[3], ['File', os.path.join(self.test_dir, 'test_file.yaml')])
+        os.remove(csv_file)
+
+    def test_load_yaml_with_cache(self):
+        analyzer = DirectoryAnalyzer()
+        file_path = os.path.join(self.test_dir, 'test_file.yaml')
+        content1 = analyzer.load_yaml_with_cache(file_path)
+        content2 = analyzer.load_yaml_with_cache(file_path)
+        self.assertEqual(content1, content2)
+        self.assertIn(file_path, analyzer.cache)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/yamlguardian/analyze_directory_structure.py
+++ b/yamlguardian/analyze_directory_structure.py
@@ -1,0 +1,57 @@
+import os
+import yaml
+import time
+import pandas as pd
+
+class DirectoryAnalyzer:
+    cache_file = 'cache.csv'
+
+    def __init__(self, cache_file=None):
+        self.cache = {}
+        self.cache_file = cache_file or DirectoryAnalyzer.cache_file
+        self.load_cache()
+
+    def load_cache(self):
+        if os.path.exists(self.cache_file):
+            df = pd.read_csv(self.cache_file)
+            for _, row in df.iterrows():
+                self.cache[row['Path']] = (yaml.safe_load(row['Content']), row['Timestamp'])
+
+    def load_yaml_with_cache(self, file_path):
+        if file_path in self.cache:
+            cached_content, cached_timestamp = self.cache[file_path]
+            current_timestamp = os.path.getmtime(file_path)
+            if current_timestamp <= cached_timestamp:
+                return cached_content
+        with open(file_path, 'r', encoding='utf-8') as file:
+            content = yaml.safe_load(file)
+            self.cache[file_path] = (content, os.path.getmtime(file_path))
+            return content
+
+    def analyze_directory_structure(self, root_dir):
+        self.load_yaml_with_cache(root_dir)
+        changes = []
+        for root, dirs, files in os.walk(root_dir):
+            for name in dirs:
+                changes.append(['Directory', os.path.join(root, name)])
+            for name in files:
+                if name.endswith('.yaml'):
+                    file_path = os.path.join(root, name)
+                    self.load_yaml_with_cache(file_path)
+                changes.append(['File', os.path.join(root, name)])
+        return changes
+
+    def save_cache(self):
+        data = []
+        for path, (content, timestamp) in self.cache.items():
+            data.append({'Path': path, 'Content': yaml.dump(content), 'Timestamp': timestamp})
+        df = pd.DataFrame(data)
+        df.to_csv(self.cache_file, index=False)
+
+if __name__ == "__main__":
+    analyzer = DirectoryAnalyzer()
+    root_directory = '.'
+    changes = analyzer.analyze_directory_structure(root_directory)
+    analyzer.save_cache()
+    print(f"Changes saved to {analyzer.cache_file}")
+    print(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}")

--- a/yamlguardian/core.py
+++ b/yamlguardian/core.py
@@ -3,12 +3,13 @@ from .validator import Validator
 from .rules import RuleManager
 from .validate import load_yaml_schema, validate_data, format_errors
 import os
+from .directory_analyzer import DirectoryAnalyzer
 
 class YamlGuardian:
     def __init__(self, schema_file, relations_file=None, common_definitions_file=None):
         self.schema = self.load_yaml(schema_file)
         self.relations = self.load_yaml(relations_file) if relations_file else None
-        self.common_definitions = self.load_yaml(common_definitions_file) if common_definitions_file else None
+        self.common_definitions = self.load_yaml(common_definitions_file) if relations_file else None
         self.rule_manager = RuleManager(self.schema, self.relations, self.common_definitions)
 
     def load_yaml(self, file_path):
@@ -39,3 +40,9 @@ class YamlGuardian:
             if errors:
                 return format_errors(errors)
         return self.rule_manager.validate(page_data)
+
+    def analyze_and_save_directory_structure(self, root_dir, csv_file):
+        analyzer = DirectoryAnalyzer()
+        changes = analyzer.analyze_directory_structure(root_dir)
+        analyzer.save_changes_to_csv(changes, csv_file)
+        analyzer.save_cache()

--- a/yamlguardian/directory_analyzer.py
+++ b/yamlguardian/directory_analyzer.py
@@ -1,0 +1,68 @@
+import os
+import yaml
+import time
+import pandas as pd
+import csv
+
+class DirectoryAnalyzer:
+    cache_file = 'cache.csv'
+
+    def __init__(self, cache_file=None):
+        self.cache = {}
+        self.cache_file = cache_file or DirectoryAnalyzer.cache_file
+        self.load_cache()
+
+    def load_cache(self):
+        if os.path.exists(self.cache_file):
+            df = pd.read_csv(self.cache_file)
+            for _, row in df.iterrows():
+                self.cache[row['Path']] = (yaml.safe_load(row['Content']), row['Timestamp'])
+
+    def load_yaml_with_cache(self, file_path):
+        if file_path in self.cache:
+            cached_content, cached_timestamp = self.cache[file_path]
+            current_timestamp = os.path.getmtime(file_path)
+            if current_timestamp <= cached_timestamp:
+                return cached_content
+        with open(file_path, 'r', encoding='utf-8') as file:
+            content = yaml.safe_load(file)
+            self.cache[file_path] = (content, os.path.getmtime(file_path))
+            return content
+
+    def analyze_directory_structure(self, root_dir):
+        self.load_yaml_with_cache(root_dir)
+        changes = []
+        for root, dirs, files in os.walk(root_dir):
+            for name in dirs:
+                changes.append(['Directory', os.path.join(root, name)])
+            for name in files:
+                if name.endswith('.yaml'):
+                    file_path = os.path.join(root, name)
+                    self.load_yaml_with_cache(file_path)
+                changes.append(['File', os.path.join(root, name)])
+        return changes
+
+    def save_changes_to_csv(self, changes, csv_file):
+        with open(csv_file, 'w', newline='') as file:
+            writer = csv.writer(file)
+            writer.writerow(['Type', 'Path'])
+            writer.writerows(changes)
+
+    def save_cache(self):
+        data = []
+        for path, (content, timestamp) in self.cache.items():
+            data.append({'Path': path, 'Content': yaml.dump(content), 'Timestamp': timestamp})
+        df = pd.DataFrame(data)
+        df.to_csv(self.cache_file, index=False)
+
+    def load_changes_from_csv(self, csv_file):
+        return pd.read_csv(csv_file)
+
+if __name__ == "__main__":
+    analyzer = DirectoryAnalyzer()
+    root_directory = '.'
+    changes = analyzer.analyze_directory_structure(root_directory)
+    analyzer.save_changes_to_csv(changes, 'directory_structure_changes.csv')
+    analyzer.save_cache()
+    print(f"Changes saved to directory_structure_changes.csv")
+    print(f"Timestamp: {time.strftime('%Y-%m-%d %H:%M:%S')}")


### PR DESCRIPTION
Add functionality to analyze directory structure and save changes in a CSV file.

* Create `yamlguardian/analyze_directory_structure.py` with `DirectoryAnalyzer` class to analyze directory structure, cache YAML files, and save changes to a CSV file.
* Modify `README.md` to include instructions for running the new script and locating the generated CSV file.
* Modify `yamlguardian/core.py` to add a method for calling the `directory_analyzer.py` script and saving changes in a CSV file.
* Add `tests/test_directory_analyzer.py` to test the new script, including directory analysis, saving changes to CSV, and caching mechanism.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/8?shareId=ee59311d-f061-4186-ba01-eeea0831d30c).