### PR TITLE
Add OpenAPI schema for YAML validation

### DIFF
--- a/rule_config/common_definitions/common_definitions.yaml
+++ b/rule_config/common_definitions/common_definitions.yaml
@@ -12,3 +12,32 @@ common_elements:
     required: false
     attributes:
       name: "commonOptions"
+
+schema:
+  type: object
+  properties:
+    common_elements:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+            description: "要素の名前"
+            required: true
+          type:
+            type: string
+            description: "要素のタイプ"
+            required: true
+          description:
+            type: string
+            description: "要素の説明"
+            required: true
+          required:
+            type: boolean
+            description: "要素が必須かどうか"
+            required: true
+          attributes:
+            type: object
+            description: "要素の属性"
+            required: false

--- a/rule_config/page_definitions/page1/root_element_relations.yaml
+++ b/rule_config/page_definitions/page1/root_element_relations.yaml
@@ -5,3 +5,24 @@ root_element_relations:
   - source: "FormC"
     target: "commonLabel"
     condition: "uses_common"  # FormCが共通ラベルを使用する場合
+
+schema:
+  type: object
+  properties:
+    root_element_relations:
+      type: array
+      items:
+        type: object
+        properties:
+          source:
+            type: string
+            description: "ソース要素の名前"
+            required: true
+          target:
+            type: string
+            description: "ターゲット要素の名前"
+            required: true
+          condition:
+            type: string
+            description: "関係の条件"
+            required: true

--- a/schema/schema.yaml
+++ b/schema/schema.yaml
@@ -1,0 +1,89 @@
+openapi: 3.0.0
+info:
+  title: YamlGuardian Schema
+  version: 1.0.0
+  description: YamlGuardianのスキーマ定義
+
+components:
+  schemas:
+    RootElement:
+      type: object
+      properties:
+        name:
+          type: string
+          description: 要素の名前
+        type:
+          type: string
+          description: 要素のタイプ
+        description:
+          type: string
+          description: 要素の説明
+        required:
+          type: boolean
+          description: 要素が必須かどうか
+        attributes:
+          type: object
+          description: 要素の属性
+          additionalProperties:
+            type: string
+        elements:
+          type: array
+          items:
+            $ref: '#/components/schemas/Element'
+    Element:
+      type: object
+      properties:
+        name:
+          type: string
+          description: 要素の名前
+        type:
+          type: string
+          description: 要素のタイプ
+        description:
+          type: string
+          description: 要素の説明
+        required:
+          type: boolean
+          description: 要素が必須かどうか
+        attributes:
+          type: object
+          description: 要素の属性
+          additionalProperties:
+            type: string
+        uses_common:
+          type: boolean
+          description: 共通要素を使用するかどうか
+    RootElementRelation:
+      type: object
+      properties:
+        source:
+          type: string
+          description: ソース要素の名前
+        target:
+          type: string
+          description: ターゲット要素の名前
+        condition:
+          type: string
+          description: 関係の条件
+    CommonElement:
+      type: object
+      properties:
+        name:
+          type: string
+          description: 要素の名前
+        type:
+          type: string
+          description: 要素のタイプ
+        description:
+          type: string
+          description: 要素の説明
+        required:
+          type: boolean
+          description: 要素が必須かどうか
+        attributes:
+          type: object
+          description: 要素の属性
+          additionalProperties:
+            type: string
+
+paths: {}

--- a/tests/rule_config/page_definitions/page1/test_invalid_data.yaml
+++ b/tests/rule_config/page_definitions/page1/test_invalid_data.yaml
@@ -1,2 +1,2 @@
-name: John
+name: 
 age: -1


### PR DESCRIPTION
Add schema information based on `DESIGN.md` and place it in the `schema` directory.

* Create `schema/schema.yaml` with schema definitions in OpenAPI format.
* Update `rule_config/common_definitions/common_definitions.yaml` to include schema information for common elements.
* Update `rule_config/page_definitions/page1/root_element_relations.yaml` to include schema information for root element relations.
* Modify `tests/rule_config/page_definitions/page1/test_invalid_data.yaml` to adjust test data.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/13?shareId=187b2bf5-43cf-4b69-9884-bd31ebf6a60d).