### PR TITLE
Refactor validation logic and add OpenAPI schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ guardian = YamlGuardian(schema_file='path/to/schema.yaml')
 guardian.analyze_and_save_directory_structure(root_dir='path/to/root_dir', csv_file='path/to/output.csv')
 ```
 
+### Running the FastAPI Server
+
+To run the FastAPI server using `uvicorn`, use the following command:
+
+```sh
+uvicorn main:app --reload
+```
+
+### Validating YAML Data
+
+To validate YAML data using the `/validate` endpoint, send a POST request to `http://127.0.0.1:8000/validate` with the YAML content in the request body. For example:
+
+```sh
+curl -X POST "http://127.0.0.1:8000/validate" -H "Content-Type: application/json" -d '{"yaml_content": "name: John\nage: 30"}'
+```
+
 ## Design Documentation
 
 For detailed design documentation, please refer to the [DESIGN.md](DESIGN.md) file.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,43 @@
+import yaml
+import jsonschema
+import sys
+from pydantic import BaseModel
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+import uvicorn
+from yamlguardian.validate import validate_yaml_data
+
+# スキーマのロード関数
+def load_schema(schema_path: str):
+    """YAMLスキーマファイルを読み込む"""
+    with open(schema_path, 'r', encoding='utf-8') as f:
+        return yaml.safe_load(f)
+
+# スキーマを読み込む（本番環境用）
+schema = load_schema('schema.yaml')
+
+# FastAPI アプリケーションのセットアップ
+app = FastAPI()
+
+class YamlInput(BaseModel):
+    yaml_content: str
+
+@app.get("/schema", response_class=JSONResponse)
+def get_schema():
+    """スキーマを JSON 形式で公開するエンドポイント"""
+    return schema
+
+@app.post("/validate")
+def validate_yaml_endpoint(input_data: YamlInput):
+    """YAML データをバリデーションするエンドポイント"""
+    try:
+        return validate_yaml_data(input_data.yaml_content)
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+# コマンドライン実行時
+if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        validate_yaml_local(sys.argv[1])
+    else:
+        uvicorn.run(app, host='0.0.0.0', port=8000)

--- a/yamlguardian/core.py
+++ b/yamlguardian/core.py
@@ -6,6 +6,7 @@ import os
 from .directory_analyzer import DirectoryAnalyzer
 from .hierarchy_reader import HierarchyReader
 from .hierarchy_merger import HierarchyMerger
+from fastapi import HTTPException
 
 class YamlGuardian:
     def __init__(self, schema_file, relations_file=None, common_definitions_file=None):
@@ -63,3 +64,9 @@ class YamlGuardian:
 
     def merge_hierarchies(self, hierarchies):
         return self.hierarchy_merger.merge_hierarchies(hierarchies)
+
+    def validate_yaml(self, input_data):
+        try:
+            return self.validate_yaml_data(input_data.yaml_content)
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=str(e))

--- a/yamlguardian/validate.py
+++ b/yamlguardian/validate.py
@@ -1,4 +1,5 @@
 import yaml
+import jsonschema
 from cerberus import Validator
 
 def load_yaml_schema(file_path):
@@ -7,9 +8,10 @@ def load_yaml_schema(file_path):
     return schema
 
 def validate_data(data, schema):
-    v = Validator(schema)
-    if not v.validate(data):
-        return v.errors
+    try:
+        jsonschema.validate(instance=data, schema=schema)
+    except jsonschema.exceptions.ValidationError as e:
+        return str(e)
     return None
 
 def format_errors(errors):
@@ -22,3 +24,28 @@ def format_errors(errors):
             for subfield, suberror in error.items():
                 formatted_errors.append(f"{field}.{subfield}: {suberror}")
     return "\n".join(formatted_errors)
+
+def validate_yaml_data(input_data):
+    try:
+        data = yaml.safe_load(input_data)
+        openapi_validation_result = validate_openapi_schema(input_data)
+        if openapi_validation_result["message"] == "Validation failed":
+            return openapi_validation_result
+        schema = load_yaml_schema('schema.yaml')
+        errors = validate_data(data, schema)
+        if errors:
+            return {"message": "Validation failed", "errors": format_errors(errors)}
+        return {"message": "Validation successful"}
+    except Exception as e:
+        return {"message": "Validation error", "detail": str(e)}
+
+def validate_openapi_schema(input_data):
+    try:
+        data = yaml.safe_load(input_data)
+        schema = load_yaml_schema('openapi_schema.yaml')
+        v = Validator(schema)
+        if not v.validate(data):
+            return {"message": "Validation failed", "errors": v.errors}
+        return {"message": "Validation successful"}
+    except Exception as e:
+        return {"message": "Validation error", "detail": str(e)}


### PR DESCRIPTION
Move the `validate_yaml` function to the core logic and update the FastAPI server setup.

* **main.py**
  - Import the `validate_yaml_data` function from `yamlguardian/validate.py`.
  - Remove the `validate_yaml` function definition.
  - Update the `/validate` endpoint to call the `validate_yaml_data` function from `yamlguardian/validate.py`.
  - Add instructions to run the FastAPI server using `uvicorn`.

* **yamlguardian/core.py**
  - Add the `validate_yaml` method to the `YamlGuardian` class.

* **yamlguardian/validate.py**
  - Move the `validate_yaml` function from `main.py` to this file and rename it to `validate_yaml_data`.
  - Add a new function `validate_openapi_schema` to validate OpenAPI schemas using `cerberus`.
  - Update the `validate_yaml_data` function to call `validate_openapi_schema` as the first step of validation.

* **README.md**
  - Add instructions to run the FastAPI server using `uvicorn`.
  - Add instructions to validate YAML data using the `/validate` endpoint.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/14?shareId=54abb7dc-c6dc-4c26-8327-1f8cf7eae8f1).