### PR TITLE
Update DESIGN.md to include validation stages

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -97,4 +97,14 @@ YAMLファイルの読み込みに失敗した場合、適切なエラーメッ�
 ### CI/CD統合
 自動化されたテストと統合を行うことで、データの整合性を継続的にチェックできるようにします。
 
+## 8. Validation Stages
+### Stage 1: Schema validation using `validate_openapi_schema`
+In this stage, the input YAML data is validated against the OpenAPI schema to ensure it conforms to the defined structure and rules.
+
+### Stage 2: User-defined YAML validation
+In this stage, the input YAML data is validated against user-defined schemas to ensure it meets the specific requirements defined by the user.
+
+### Stage 3: User-provided YAML validation
+In this stage, the input YAML data is validated against the schemas provided by the user to ensure it adheres to the expected format and rules.
+
 この設計文書は、YamlGuardianの全体的な構造と機能を明確に示しています。この文書を基に、開発を進めることができます。必要に応じて、さらなる詳細や仕様を追加することが可能です。

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
 import uvicorn
-from yamlguardian.validate import validate_yaml_data
+from yamlguardian.validate import validate_yaml_data, validate_openapi_schema, validate_user_defined_yaml, validate_user_provided_yaml
 
 # スキーマのロード関数
 def load_schema(schema_path: str):
@@ -31,7 +31,19 @@ def get_schema():
 def validate_yaml_endpoint(input_data: YamlInput):
     """YAML データをバリデーションするエンドポイント"""
     try:
-        return validate_yaml_data(input_data.yaml_content)
+        openapi_result = validate_openapi_schema(input_data.yaml_content)
+        if openapi_result["message"] == "Validation failed":
+            return openapi_result
+
+        user_defined_result = validate_user_defined_yaml(input_data.yaml_content)
+        if user_defined_result["message"] == "Validation failed":
+            return user_defined_result
+
+        user_provided_result = validate_user_provided_yaml(input_data.yaml_content)
+        if user_provided_result["message"] == "Validation failed":
+            return user_provided_result
+
+        return {"message": "Validation successful"}
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,6 @@
 import unittest
 import yaml
-from yamlguardian.validate import load_yaml_schema, validate_data, format_errors
+from yamlguardian.validate import load_yaml_schema, validate_data, format_errors, validate_openapi_schema, validate_user_defined_yaml, validate_user_provided_yaml
 from yamlguardian.validator import Validator
 from yamlguardian.rules import RuleManager
 from yamlguardian.core import YamlGuardian
@@ -194,6 +194,45 @@ class TestValidate(unittest.TestCase):
         }
         errors = yaml_guardian.validate_page(page_data, 'rule_config/page_definitions/page1')
         self.assertIsNotNone(errors)
+
+    def test_validate_openapi_schema(self):
+        input_data = """
+        openapi: 3.0.0
+        info:
+          title: Sample API
+          version: 1.0.0
+          description: A sample API
+        paths:
+          /sample:
+            get:
+              description: Sample GET endpoint
+        """
+        result = validate_openapi_schema(input_data)
+        self.assertEqual(result["message"], "Validation successful")
+
+    def test_validate_user_defined_yaml(self):
+        input_data = """
+        name: UserDefined
+        type: custom
+        description: A user defined YAML
+        required: true
+        attributes:
+          key: value
+        """
+        result = validate_user_defined_yaml(input_data)
+        self.assertEqual(result["message"], "Validation successful")
+
+    def test_validate_user_provided_yaml(self):
+        input_data = """
+        name: UserProvided
+        type: custom
+        description: A user provided YAML
+        required: true
+        attributes:
+          key: value
+        """
+        result = validate_user_provided_yaml(input_data)
+        self.assertEqual(result["message"], "Validation successful")
 
 if __name__ == '__main__':
     unittest.main()

--- a/yamlguardian/validate.py
+++ b/yamlguardian/validate.py
@@ -31,6 +31,12 @@ def validate_yaml_data(input_data):
         openapi_validation_result = validate_openapi_schema(input_data)
         if openapi_validation_result["message"] == "Validation failed":
             return openapi_validation_result
+        user_defined_validation_result = validate_user_defined_yaml(input_data)
+        if user_defined_validation_result["message"] == "Validation failed":
+            return user_defined_validation_result
+        user_provided_validation_result = validate_user_provided_yaml(input_data)
+        if user_provided_validation_result["message"] == "Validation failed":
+            return user_provided_validation_result
         schema = load_yaml_schema('schema.yaml')
         errors = validate_data(data, schema)
         if errors:
@@ -43,6 +49,28 @@ def validate_openapi_schema(input_data):
     try:
         data = yaml.safe_load(input_data)
         schema = load_yaml_schema('openapi_schema.yaml')
+        v = Validator(schema)
+        if not v.validate(data):
+            return {"message": "Validation failed", "errors": v.errors}
+        return {"message": "Validation successful"}
+    except Exception as e:
+        return {"message": "Validation error", "detail": str(e)}
+
+def validate_user_defined_yaml(input_data):
+    try:
+        data = yaml.safe_load(input_data)
+        schema = load_yaml_schema('user_defined_yaml.yaml')
+        v = Validator(schema)
+        if not v.validate(data):
+            return {"message": "Validation failed", "errors": v.errors}
+        return {"message": "Validation successful"}
+    except Exception as e:
+        return {"message": "Validation error", "detail": str(e)}
+
+def validate_user_provided_yaml(input_data):
+    try:
+        data = yaml.safe_load(input_data)
+        schema = load_yaml_schema('user_provided_yaml.yaml')
         v = Validator(schema)
         if not v.validate(data):
             return {"message": "Validation failed", "errors": v.errors}


### PR DESCRIPTION
Update `DESIGN.md` to include the three stages of validation for YamlGuardian.

* **Validation Stages**:
  - Add a new section "## 8. Validation Stages" to describe the three stages of validation.
  - Describe Stage 1: Schema validation using `validate_openapi_schema`.
  - Describe Stage 2: User-defined YAML validation.
  - Describe Stage 3: User-provided YAML validation.

* **Code Changes**:
  - Modify `main.py` to include the three stages of validation in the `validate_yaml_endpoint` function.
  - Update `yamlguardian/validate.py` to add functions `validate_user_defined_yaml` and `validate_user_provided_yaml`.
  - Update `tests/test_validate.py` to include tests for `validate_openapi_schema`, `validate_user_defined_yaml`, and `validate_user_provided_yaml`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/15?shareId=8d4fc2be-db7f-4b71-a0a1-01d8f9db37df).