### PR TITLE
Fix CI errors in tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ import subprocess
 import os
 from yamlguardian import cli
 import cerberus
+import jsonschema
 
 class TestCLISuccess(unittest.TestCase):
 

--- a/tests/test_directory_analyzer.py
+++ b/tests/test_directory_analyzer.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import csv
 from yamlguardian.directory_analyzer import DirectoryAnalyzer
+import pandas as pd
 
 class TestDirectoryAnalyzer(unittest.TestCase):
 

--- a/tests/test_json_schema_adapter.py
+++ b/tests/test_json_schema_adapter.py
@@ -1,5 +1,5 @@
 import unittest
-from yamlguardian.json_schema_adapter import convert_yaml_to_json_schema, load_yaml_file
+from yamlguardian.yaml_to_json_schema import convert_yaml_to_json_schema, load_yaml_file
 
 class TestConvertYamlToJsonSchema(unittest.TestCase):
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,6 @@
 import unittest
 import yaml
+import jsonschema
 from yamlguardian.validate import load_validation_rules, validate_data, format_errors, validate_openapi_schema, validate_user_defined_yaml, validate_user_provided_yaml
 from yamlguardian.validator import Validator
 from yamlguardian.rules import RuleManager

--- a/tests/test_yaml_to_json_schema.py
+++ b/tests/test_yaml_to_json_schema.py
@@ -1,5 +1,5 @@
 import unittest
-from yamlguardian.yaml_to_json_schema import convert_yaml_to_json_schema, load_yaml_file
+from yamlguardian.yaml_to_json_schema import yaml_to_json_schema, load_yaml_file
 
 class TestConvertYamlToJsonSchema(unittest.TestCase):
 
@@ -7,7 +7,7 @@ class TestConvertYamlToJsonSchema(unittest.TestCase):
         yaml_schema = {
             'name': {'type': 'string', 'minlength': 1, 'maxlength': 50, 'required': True}
         }
-        json_schema = convert_yaml_to_json_schema(yaml_schema)
+        json_schema = yaml_to_json_schema(yaml_schema)
         self.assertEqual(json_schema['properties']['name']['type'], 'string')
         self.assertEqual(json_schema['properties']['name']['minLength'], 1)
         self.assertEqual(json_schema['properties']['name']['maxLength'], 50)
@@ -17,7 +17,7 @@ class TestConvertYamlToJsonSchema(unittest.TestCase):
         yaml_schema = {
             'age': {'type': 'integer', 'min': 0, 'required': True}
         }
-        json_schema = convert_yaml_to_json_schema(yaml_schema)
+        json_schema = yaml_to_json_schema(yaml_schema)
         self.assertEqual(json_schema['properties']['age']['type'], 'integer')
         self.assertIn('age', json_schema['required'])
 


### PR DESCRIPTION
Fix CI errors by updating import statements and correcting function names.

* **tests/test_cli.py**
  - Add `jsonschema` module import statement.

* **tests/test_directory_analyzer.py**
  - Add `pandas` module import statement.

* **tests/test_json_schema_adapter.py**
  - Update import statement to correctly import `convert_yaml_to_json_schema` function from `yamlguardian.yaml_to_json_schema`.

* **tests/test_validate.py**
  - Add `jsonschema` module import statement.

* **tests/test_yaml_to_json_schema.py**
  - Update import statement to correctly import `yaml_to_json_schema` function from `yamlguardian.yaml_to_json_schema`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/22?shareId=a2eaef55-9044-445b-803b-6b8e02d73e51).