### PR TITLE
Fix Cerberus schema to include 'min' key for 'age' field

### DIFF
--- a/yamlguardian/cerberus_adapter.py
+++ b/yamlguardian/cerberus_adapter.py
@@ -13,6 +13,8 @@ def convert_yaml_to_cerberus(yaml_schema):
                 cerberus_rules['maxlength'] = value
             elif rule == 'required':
                 cerberus_rules['required'] = value
+            elif rule == 'min':
+                cerberus_rules['min'] = value
             # Add more mappings as needed
         cerberus_schema[field] = cerberus_rules
     return cerberus_schema


### PR DESCRIPTION
Add mapping for 'min' key in `convert_yaml_to_cerberus` function.

* Update `yamlguardian/cerberus_adapter.py` to include 'min' key mapping from the YAML schema to the Cerberus schema.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nobu007/YamlGuardian/pull/24?shareId=a48deec2-9759-43ca-ae0f-b22f02f39205).